### PR TITLE
Add before and after functionallity through pub sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.0.0
-## 2019-XX-XX (TBD)
+## 2019-08-29
 - Remove `procedure` module
 - Add `onsuccess` and `onfail` arguments (to replace `procedure` behaviour)
 - Add custom functionality to shutdown using a built in pub/sub mechanism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.0
+## 2019-XX-XX (TBD)
+- Remove `procedure` module
+- Add `onsuccess` and `onfail` arguments (to replace `procedure` behaviour)
+- Add custom functionality to shutdown using a built in pub/sub mechanism
+
 # 1.2.1
 ## 2019-08-22
 [administrative detail] Migrate to another repo

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# @routes/graceful-shutdown <a href="https://www.npmjs.com/package/@routes/graceful-shutdown"><img src="https://img.shields.io/npm/v/@routes/graceful-shutdown.svg"></a> [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/omrilotan/express-graceful-shutdown)
+# @routes/graceful-shutdown <a href="https://www.npmjs.com/package/@routes/graceful-shutdown"><img src="https://img.shields.io/npm/v/@routes/graceful-shutdown.svg"></a> [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/omrilotan/graceful-shutdown)
 
 ## 💀 Shut down server gracefully
 
-[![](https://circleci.com/gh/omrilotan/express-graceful-shutdown.svg?style=svg)](https://circleci.com/gh/omrilotan/express-graceful-shutdown) [![](https://snyk.io/test/github/omrilotan/express-graceful-shutdown/badge.svg)](https://snyk.io/test/github/omrilotan/express-graceful-shutdown) [![](https://api.codeclimate.com/v1/badges/7914da297e8693bba8f6/maintainability)](https://codeclimate.com/github/omrilotan/express-graceful-shutdown/maintainability)
+[![](https://circleci.com/gh/omrilotan/graceful-shutdown.svg?style=svg)](https://circleci.com/gh/omrilotan/graceful-shutdown) [![](https://snyk.io/test/github/omrilotan/graceful-shutdown/badge.svg)](https://snyk.io/test/github/omrilotan/graceful-shutdown) [![](https://api.codeclimate.com/v1/badges/7914da297e8693bba8f6/maintainability)](https://codeclimate.com/github/omrilotan/graceful-shutdown/maintainability)
 
 [net.Server](https://nodejs.org/api/net.html#net_class_net_server) or [Express](https://expressjs.com/en/api.html#app.listen), whatever you're using should be fine
 
@@ -45,7 +45,7 @@ graceful(server, {
 ## Add custom functionality to shutdown
 Add behaviour to the graceful shut down process using a built in pub/sub mechanism
 ```js
-const { sub, BEFORE, AFTER } = graceful(server {...});
+const { sub, BEFORE, AFTER } = graceful(server, {...});
 
 // Will be triggered first thing before the procedure starts
 sub(BEFORE, async() => {

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ graceful(server);
 | option | type | meaning | default
 | - | - | - | -
 | `timeout` | Number | Time (in milliseconds) to wait before forcefully shutting down | `10000` (10 sec)
-| `logger` | Object | Object with `info` and `error` functions (supports async loggers) | `console`
+| `logger` | Object | Object with `info` and `error` functions (supports async loggers). Pass `false` to disable | `console`
 | `events` | Array | Process events to handle | `['SIGTERM', 'SIGINT']`
+| `onsuccess` | Function | Final functionality when shutdown finished correctly | `process.exit(0)`
+| `onfail` | Function | Final functionality when shutdown finished incorrectly | `process.exit(1)`
 
 Example of using options
 ```js
@@ -35,35 +37,25 @@ graceful(server, {
 1. Process termination is interrupted
 2. Open connections are instructed to end (FIN packet) and receive a new timeout to allow them to close in time
 3. The server is firing a close function
-4. After correct closing the process exists with exit code 0
+4. After correct closing: `onsuccess` (default: process exists with exit code 0)
 	- _End correct behaviour_
 5. After `timeout` passes - an error log is printed with the amount of connection that will be forcefully terminated
-6. Process exists with an exit code 1
+6. `onfail`: (default: process exists with an exit code 1)
 
-## Procedure as a module
-In case you wish to apply termination interruption yourself, use `procedure` interface:
+## Add custom functionality to shutdown
+Add behaviour to the graceful shut down process using a built in pub/sub mechanism
 ```js
-const { procedure } = require('@routes/graceful-shutdown');
+const { sub, BEFORE, AFTER } = graceful(server {...});
 
-const shutdown = procedure(server, {
-	timeout: 1e4,
-	logger: {info: msg => null, error: msg => null},
-	onsuccess: () => null,
-	onfail: () => null,
+// Will be triggered first thing before the procedure starts
+sub(BEFORE, async() => {
+	await flushThrottledThings();
+	await closeDatabaseConnections();
 });
 
-// Apply procedure to termination
-process.stdin.resume();
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+// Will be triggered once the procedure has ended
+sub(AFTER, () => logger.info('Okay okay, closing down'));
 ```
-
-| option | type | meaning | default
-| - | - | - | -
-| `timeout` | Number | Time (in milliseconds) to wait before forcefully shutting down | `10000` (10 sec)
-| `logger` | Object | Object with `info`, and `error` functions (supports async loggers) | `console`
-| `onsuccess` | Function | Callback when shutdown finished correctly | `process.exit(0)`
-| `onsuccess` | Function | Callback when shutdown finished incorrectly | `process.exit(1)`
 
 ## `server.shuttingDown`
 After shutdown has initiated, the attribute `shuttingDown` is attached to server with value of `true`.

--- a/index.js
+++ b/index.js
@@ -1,28 +1,31 @@
+const { BEFORE, AFTER } = require('./lib/eventNames');
+const { pub, sub } = require('./lib/pubsub');
 const procedure = require('./lib/procedure');
-
-/**
- * Default process events to listen to
- * @type {Array}
- */
-const DEFAULT_EVENTS = [
-	'SIGTERM',
-	'SIGINT',
-];
 
 /**
  * Register signal termination to shut service down gracefully
  * @param  {net.Server} server  net.Server
  * @param  {Number}     [options.timeout=10000]
  * @param  {Object}     [options.logger=console]
+ * @param  {Array}      [options.events=['SIGTERM', 'SIGINT']]
  * @return {undefined}
  */
-function graceful(server, {timeout = 10000, logger = console, events = DEFAULT_EVENTS} = {}) {
-	const action = procedure(server, {timeout, logger});
+function graceful(
+		server,
+		{
+			timeout = 10000,
+			logger = console,
+			events = ['SIGTERM', 'SIGINT'],
+			onsuccess = () => process.exit(0),
+			onfail = () => process.exit(1),
+		} = {}
+) {
+	const action = procedure(server, {timeout, logger, onsuccess, onfail, pub});
 
 	process.stdin.resume();
 	events.forEach(event => process.on(event, action));
-}
 
-graceful.procedure = procedure;
+	return { sub, BEFORE, AFTER };
+}
 
 module.exports = graceful;

--- a/lib/eventNames/index.js
+++ b/lib/eventNames/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	BEFORE: {},
+	AFTER: {},
+};

--- a/lib/forceShutdown/index.js
+++ b/lib/forceShutdown/index.js
@@ -1,3 +1,4 @@
+const { AFTER } = require('../eventNames');
 const getConnections = require('../getConnections');
 
 /**
@@ -5,9 +6,10 @@ const getConnections = require('../getConnections');
  * @param  {net.Server} options.server
  * @param  {Number}     options.timeout
  * @param  {Function}   options.logger
+ * @param  {Object}     options.pubsub.pub event manager
  * @return {undefined<Promise>}
  */
-module.exports = ({server, timeout, logger, onsuccess, onfail}) => new Promise(
+module.exports = ({server, timeout, logger, onsuccess, onfail, pub}) => new Promise(
 	(resolve, reject) => setTimeout(
 		async() => {
 			try {
@@ -15,9 +17,11 @@ module.exports = ({server, timeout, logger, onsuccess, onfail}) => new Promise(
 
 				if (connections > 0) {
 					await logger.error(`Closed service forcefully with ${connections} connections.`);
+					await pub(AFTER);
 					onfail();
 				} else {
 					await logger.info('Closed down with no connections');
+					await pub(AFTER);
 					onsuccess();
 				}
 				resolve();

--- a/lib/forceShutdown/spec.js
+++ b/lib/forceShutdown/spec.js
@@ -1,48 +1,50 @@
 const wait = require('@lets/wait');
+const { AFTER } = require('../eventNames');
 
 const { clean, override } = abuser(__filename);
-const getConnections = stub();
 
 let forceShutdown;
 
-const { server, logger, onsuccess, onfail } = require('../stubs');
+const {
+	getConnections,
+	logger,
+	onfail,
+	onsuccess,
+	pubsub: { pub },
+	reset,
+	server,
+} = require('../stubs');
 
 
-describe('graceful-shutdown/lib/forceShutdown', () => {
+describe('lib/forceShutdown', () => {
 	before(() => {
 		override('../getConnections', getConnections);
 		forceShutdown = require('.');
 	});
-	afterEach(() => {
-		getConnections.reset();
-		onsuccess.reset();
-		onfail.reset();
-		logger.info.reset();
-		logger.error.reset();
-	});
+	afterEach(reset);
 	after(() => clean('.'));
 
 	it('Should call on getConnections', async() => {
-		await forceShutdown({server, logger, onsuccess, onfail});
+		await forceShutdown({server, logger, onsuccess, onfail, pub});
 		expect(getConnections).to.have.been.calledWith(server);
 	});
 	it('Should log error and exit with code 1 if there are open connections', async() => {
 		getConnections.returns(2);
-		await forceShutdown({server, logger, onsuccess, onfail});
+		await forceShutdown({server, logger, onsuccess, onfail, pub});
 		expect(logger.info).to.not.have.been.called;
 		expect(logger.error).to.have.been.called;
 		expect(onfail).to.have.been.called;
 	});
 	it('Should log info and exit with code 0 if there are open connections', async() => {
 		getConnections.returns(0);
-		await forceShutdown({server, logger, onsuccess, onfail});
+		await forceShutdown({server, logger, onsuccess, onfail, pub});
 		expect(logger.error).to.not.have.been.called;
 		expect(logger.info).to.have.been.called;
 		expect(onsuccess).to.have.been.called;
 	});
 	it('Should wait for async logger before exiting', async() => {
 		const later = spy();
-		await forceShutdown({server, onsuccess, onfail, logger: {
+		await forceShutdown({server, onsuccess, onfail, pub, logger: {
 			info: async() => {
 				await wait(400);
 				expect(onsuccess).to.not.have.been.called;
@@ -52,5 +54,32 @@ describe('graceful-shutdown/lib/forceShutdown', () => {
 		}});
 		expect(later).to.have.been.called;
 		expect(onsuccess).to.have.been.called;
+	});
+	it('Should trigger pub with AFTER event on fail or success', async() => {
+		getConnections.returns(0);
+		await forceShutdown({server, logger, onsuccess, onfail, pub});
+		expect(pub).to.have.been.calledWith(AFTER);
+
+		pub.reset();
+
+		getConnections.returns(2);
+		await forceShutdown({server, logger, onsuccess, onfail, pub});
+		expect(pub).to.have.been.calledWith(AFTER);
+	});
+	it('Should trigger pub with AFTER event when success callback has an error', async() => {
+		getConnections.returns(0);
+		const throws = () => { throw new Error('Something must have gone terribly wrong.'); };
+		const onfail = throws;
+		const onsuccess = onfail;
+		await forceShutdown({server, logger, onsuccess, onfail, pub}).catch(() => void(0));
+		expect(pub).to.have.been.calledWith(AFTER);
+	});
+	it('Should trigger pub with AFTER event when fail callback has an error', async() => {
+		getConnections.returns(2);
+		const throws = () => { throw new Error('Something must have gone terribly wrong.'); };
+		const onfail = throws;
+		const onsuccess = onfail;
+		await forceShutdown({server, logger, onsuccess, onfail, pub}).catch(() => void(0));
+		expect(pub).to.have.been.calledWith(AFTER);
 	});
 });

--- a/lib/getConnections/index.js
+++ b/lib/getConnections/index.js
@@ -1,6 +1,6 @@
 /**
- * Express server getConnections in promise form
- * @param  {net.Server} server Express server instance
+ * Server getConnections in promise form
+ * @param  {net.Server} server Server instance
  * @return {Number<Promise>}
  */
 module.exports = server => new Promise(

--- a/lib/procedure/index.js
+++ b/lib/procedure/index.js
@@ -3,7 +3,7 @@ const shutdown = require('../shutdown');
 
 /**
  * Register signal termination to shut service down gracefully
- * @param  {net.Server} server  Express Server
+ * @param  {net.Server} server  Server instance
  * @param  {Number}     [options.timeout=10000]
  * @param  {Object}     [options.logger=console]
  * @return {Function}

--- a/lib/procedure/index.js
+++ b/lib/procedure/index.js
@@ -13,6 +13,7 @@ module.exports = function procedure(server, {
 	logger = console,
 	onsuccess = () => process.exit(0),
 	onfail = () => process.exit(1),
+	pub,
 } = {}) {
 	if (logger === false) {
 		logger = new Proxy({}, {get: () => () => null});
@@ -20,6 +21,6 @@ module.exports = function procedure(server, {
 
 	const sockets = socketManager({server});
 
-	return () => shutdown({server, timeout, logger, sockets, onsuccess, onfail});
+	return () => shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
 };
 

--- a/lib/procedure/spec.js
+++ b/lib/procedure/spec.js
@@ -1,12 +1,21 @@
 const { clean, override } = abuser(__filename);
 
-const socketManager = stub();
-const shutdown = stub();
 let procedure;
 
-const { sockets, server, timeout, logger, onsuccess, onfail } = require('../stubs');
+const {
+	logger,
+	onfail,
+	onsuccess,
+	pubsub: { pub },
+	reset,
+	server,
+	shutdown,
+	socketManager,
+	sockets,
+	timeout,
+} = require('../stubs');
 
-describe('graceful-shutdown/lib/procedure', () => {
+describe('lib/procedure', () => {
 	const { exit } = process;
 	before(() => {
 		process.exit = stub();
@@ -18,13 +27,7 @@ describe('graceful-shutdown/lib/procedure', () => {
 		procedure = require('.');
 	});
 	afterEach(() => {
-		socketManager.reset();
-		socketManager.returns(sockets);
-		onsuccess.reset();
-		onfail.reset();
-		shutdown.reset();
-		logger.info.reset();
-		logger.error.reset();
+		reset();
 		process.exit.reset();
 	});
 
@@ -38,9 +41,9 @@ describe('graceful-shutdown/lib/procedure', () => {
 		expect(socketManager).to.have.been.calledWith({server});
 	});
 	it('Should return a shutdown callback bound to arguments and sockets', async() => {
-		const fn = await procedure(server, {timeout, logger, onsuccess, onfail});
+		const fn = await procedure(server, {timeout, logger, onsuccess, onfail, pub});
 		fn();
-		expect(shutdown).to.have.been.calledWith({server, timeout, logger, sockets, onsuccess, onfail});
+		expect(shutdown).to.have.been.calledWith({server, timeout, logger, sockets, onsuccess, onfail, pub});
 	});
 	it('Should default timeout to 10 seconds', async() => {
 		const fn = await procedure(server);

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -1,0 +1,36 @@
+/**
+ * Event store
+ * @type {Map}
+ */
+const store = new Map();
+
+/**
+ * pub/sub instance
+ * @type {Object}
+ * @property {Function} sub
+ * @property {Function} pub
+ */
+module.exports = {
+
+	/**
+	 * Subscribe function
+	 * @param  {Any}      identifier
+	 * @param  {Function} callback
+	 */
+	sub: (identifier, callback) => {
+		store.has(identifier) || store.set(identifier, new Set());
+		store.get(identifier).add(callback);
+	},
+
+	/**
+	 * Publish event
+	 * @param  {Any}   identifier
+	 */
+	pub: async identifier => store.has(identifier) && await Promise.all(
+		Array.from(
+			store.get(identifier)
+		).map(
+			callback => callback.call()
+		)
+	),
+};

--- a/lib/pubsub/spec.js
+++ b/lib/pubsub/spec.js
@@ -1,0 +1,46 @@
+const wait = require('@lets/wait');
+const { pub, sub } = require('.');
+
+describe('lib/pubsub', () => {
+	let n = 0;
+	let NAME;
+	beforeEach(() => {
+		NAME = `event-name-${++n}`;
+	});
+
+	it('Should not break on a missing set', async() => {
+		expect(async () => await pub(NAME)).not.to.throw();
+	});
+
+	it('Should fire up a sub on pub', async() => {
+		const fn = spy();
+
+		sub(NAME, fn);
+		expect(fn, 'sub').to.not.have.been.called;
+		pub(NAME);
+		expect(fn, 'pub').to.have.been.called;
+	});
+
+	it('Should wait for async functions', async() => {
+		const fn = spy();
+
+		sub(NAME, async() => {
+			await wait(10);
+			fn();
+		});
+		expect(fn, 'sub').to.not.have.been.called;
+		const p = pub(NAME);
+		expect(fn, 'sub').to.not.have.been.called;
+		await p;
+		expect(fn, 'pub').to.have.been.called;
+	});
+
+	it('Should call multiple callbacks', () => {
+		const fns = [spy(), spy()];
+		sub(NAME, fns[0]);
+		sub(NAME, fns[1]);
+		pub(NAME);
+		expect(fns[0], 'pub').to.have.been.called;
+		expect(fns[1], 'pub').to.have.been.called;
+	});
+});

--- a/lib/shutdown/index.js
+++ b/lib/shutdown/index.js
@@ -1,5 +1,6 @@
-const getConnections = require('../getConnections');
+const { BEFORE, AFTER } = require('../eventNames');
 const forceShutdown = require('../forceShutdown');
+const getConnections = require('../getConnections');
 
 /**
  * Shutdown gracefully (delayed event)
@@ -7,11 +8,15 @@ const forceShutdown = require('../forceShutdown');
  * @param  {Number}     options.timeout
  * @param  {Function}   options.logger
  * @param  {Set}        options.sockets
+ * @param  {Object}     options.pub
  * @return {undefined}
  */
-module.exports = async function shutdown({server, timeout, logger, sockets, onsuccess, onfail}) {
+module.exports = async function shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub}) {
 	if (server.shuttingDown) { return; }
-	server.shuttingDown = true;
+
+	await pub(BEFORE);
+
+	server.shuttingDown = true; // eslint-disable-line require-atomic-updates
 
 	logger.info(`Started shutdown process with ${await getConnections(server)} connections and timeout of ${timeout} ms`);
 
@@ -25,12 +30,13 @@ module.exports = async function shutdown({server, timeout, logger, sockets, onsu
 
 	try {
 		logger.info('Asking server to close');
-		server.close(function resolution() {
+		server.close(async function resolution() {
 			logger.info('Closed server successfully');
+			await pub(AFTER);
 			onsuccess();
 		});
 
-		await forceShutdown({server, timeout, logger, onsuccess, onfail});
+		await forceShutdown({server, timeout, logger, onsuccess, onfail, pub});
 
 	} catch (error) {
 		logger.error(error);

--- a/lib/shutdown/spec.js
+++ b/lib/shutdown/spec.js
@@ -1,61 +1,76 @@
+const wait = require('@lets/wait');
+
 const { clean, override } = abuser(__filename);
 
-const getConnections = stub();
-const forceShutdown = stub();
 let shutdown;
 
-const { sockets, socket, server, timeout, logger, onsuccess, onfail } = require('../stubs');
+const {
+	forceShutdown,
+	getConnections,
+	logger,
+	onfail,
+	onsuccess,
+	pubsub: { pub },
+	reset,
+	server,
+	socket,
+	sockets,
+	timeout,
+} = require('../stubs');
 
-describe('graceful-shutdown/lib/shutdown', () => {
+describe('lib/shutdown', () => {
 	beforeEach(() => {
 		clean('.');
 		override('../getConnections', getConnections);
 		override('../forceShutdown', forceShutdown);
 		shutdown = require('.');
 	});
-	afterEach(() => {
-		delete server.shuttingDown;
-		getConnections.reset();
-		forceShutdown.reset();
-		onsuccess.reset();
-		onfail.reset();
-		server.close.reset();
-		socket.setTimeout.reset();
-		logger.info.reset();
-		logger.error.reset();
-	});
+	afterEach(reset);
 
 	after(() => clean('.'));
 
 	it('Should call server.close', async() => {
-		await shutdown({server, timeout, logger, sockets, onsuccess, onfail});
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
 		expect(server.close).to.have.been.called;
 	});
 	it('Should log an error when server close can not be called', async() => {
 		const error = new Error('Something must have gone wrong');
 		server.close.throws(error);
-		await shutdown({server, timeout, logger, sockets});
+		await shutdown({server, timeout, logger, sockets, pub});
 		expect(logger.error).to.have.been.called;
 	});
 	it('Should call server.close only once', async() => {
-		await shutdown({server, timeout, logger, sockets, onsuccess, onfail});
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
 		expect(server.close).to.have.been.called;
 		server.close.reset();
-		await shutdown({server, timeout, logger, sockets});
+		await shutdown({server, timeout, logger, sockets, pub});
 		expect(server.close).to.not.have.been.called;
 	});
 	it('Should call server.close unless server.shuttingDown is true', async() => {
 		server.shuttingDown = true;
-		await shutdown({server, timeout, logger, sockets});
+		await shutdown({server, timeout, logger, sockets, pub});
 		expect(server.close).to.not.have.been.called;
 	});
 	it('Should exit the onsucess finally after server is closed correctly', async() => {
-		await shutdown({server, timeout, logger, sockets, onsuccess, onfail});
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
 		server.close.firstCall.args[0](); // Call the callback
+		await wait();
 		expect(onsuccess).to.have.been.called;
 	});
+	it('Should set timeout for all sockets', async() => {
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
+		expect(socket.setTimeout).to.have.been.calledThrice;
+		expect(socket.on).to.have.been.calledThrice;
+	});
+	it('Should register call for socket end on socket timeout', async() => {
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
+		expect(socket.on).to.have.been.calledWith('timeout');
+		expect(socket.end).to.not.have.been.called;
+		socket.on.firstCall.args[1]();
+		expect(socket.end).to.have.been.called;
+	});
 	it('Calls forceShutdown finally', async() => {
-		await shutdown({server, timeout, logger, sockets, onsuccess, onfail});
-		expect(forceShutdown).to.have.been.calledWith({server, timeout, logger, onsuccess, onfail});
+		await shutdown({server, timeout, logger, sockets, onsuccess, onfail, pub});
+		expect(forceShutdown).to.have.been.calledWith({server, timeout, logger, onsuccess, onfail, pub});
 	});
 });

--- a/lib/socketManager/spec.js
+++ b/lib/socketManager/spec.js
@@ -10,7 +10,7 @@ const server = {
 	},
 };
 
-describe('graceful-shutdown/lib/socketManager', () => {
+describe('lib/socketManager', () => {
 	beforeEach(() => {
 		delete server.callback;
 	});

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -5,17 +5,57 @@ Object.defineProperty(
 	module,
 	'exports',
 	{
-		get: () => ({
-			sockets: new Set(),
-			socket: { setTimeout: stub() },
-			server: { close: stub() },
-			timeout: 7,
-			logger: {
-				info: stub(),
-				error: stub(),
-			},
-			onsuccess: stub(),
-			onfail: stub(),
-		}),
+		get: () => {
+			const forceShutdown = stub();
+			const getConnections = stub();
+			const logger = { info: stub(), error: stub() };
+			const onfail = stub();
+			const onsuccess = stub();
+			const pubsub = { pub: stub(), sub: stub() };
+			const server = { close: stub() };
+			const shutdown = stub();
+			const socket = { setTimeout: stub(), on: stub(), end: stub() };
+			const socketManager = stub();
+			const sockets = new Set();
+			const timeout = 7;
+			sockets.add(Object.assign({}, socket));
+			sockets.add(Object.assign({}, socket));
+			sockets.add(Object.assign({}, socket));
+
+			function reset() {
+				forceShutdown.reset();
+				getConnections.reset();
+				logger.error.reset();
+				logger.info.reset();
+				onfail.reset();
+				onsuccess.reset();
+				pubsub.pub.reset();
+				pubsub.sub.reset();
+				server.close.reset();
+				shutdown.reset();
+				socket.end.reset();
+				socket.on.reset();
+				socket.setTimeout.reset();
+				socketManager.reset();
+				socketManager.returns(sockets);
+				delete server.shuttingDown;
+			}
+
+			return {
+				forceShutdown,
+				getConnections,
+				logger,
+				onfail,
+				onsuccess,
+				pubsub,
+				reset,
+				server,
+				shutdown,
+				socket,
+				socketManager,
+				sockets,
+				timeout,
+			};
+		},
 	}
 );

--- a/package.json
+++ b/package.json
@@ -7,16 +7,17 @@
     "graceful-shutdown",
     "SIGTERM",
     "socket termination",
+    "server",
     "express",
     "rolling service",
     "💀"
   ],
-  "homepage": "https://omrilotan.com/express-graceful-shutdown",
+  "homepage": "https://omrilotan.com/graceful-shutdown",
   "author": "omrilotan",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/omrilotan/express-graceful-shutdown.git",
+    "url": "git+https://github.com/omrilotan/graceful-shutdown.git",
     "directory": "packages/graceful-shutdown"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/omrilotan/graceful-shutdown.git",
-    "directory": "packages/graceful-shutdown"
+    "url": "git+https://github.com/omrilotan/graceful-shutdown.git"
   },
   "scripts": {
     "start": "node --experimental-modules --es-module-specifier-resolution=node app",


### PR DESCRIPTION
Address issue #1 :

> ![](https://avatars2.githubusercontent.com/u/38615932?s=48&v=4) @OlegYudovichFiverr
> The services which open connections such Redis, MongoDB, need to close these connections before process termination. It will good to have kind of custom Promise which will resolve all opened connections or list of promises as one of the additional parameters in `graceful` function.
> You will await for promise resolve before process termination in graceful or in case of list of promises `Promise.all`.

### Example:
_(available in README)_
```js
const { sub, BEFORE, AFTER } = graceful(server, {...});

// Will be triggered first thing before the procedure starts
sub(BEFORE, async() => {
	await flushThrottledThings();
	await closeDatabaseConnections();
});

// Will be triggered once the procedure has ended
sub(AFTER, () => logger.info('Okay okay, closing down'));
```

## CHANGELOG
- Remove `procedure` module
- Add `onsuccess` and `onfail` arguments (to replace `procedure` behaviour)
- Add custom functionality to shutdown using a built in pub/sub mechanism